### PR TITLE
Bump zookeeper from 3.3.6 to 3.4.14 in /第12课/demo

### DIFF
--- a/第12课/demo/pom.xml
+++ b/第12课/demo/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.3.6</version>
+            <version>3.4.14</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Bumps zookeeper from 3.3.6 to 3.4.14.

---
updated-dependencies:
- dependency-name: org.apache.zookeeper:zookeeper dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>